### PR TITLE
install the server-side apps

### DIFF
--- a/charts-external/auth/healthcheck.sh
+++ b/charts-external/auth/healthcheck.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-echo chart is not ready, skipping health check
-exit 0
-
 kubectl rollout status deployment/auth

--- a/charts-external/auth/templates/configmap.yaml
+++ b/charts-external/auth/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth
+data:
+  # DATABASE_URL: postgresql://*********@budgetkey-postgres/private'
+  EXTERNAL_ADDRESS: next.obudget.org
+  # GOOGLE_KEY: *********.apps.googleusercontent.com
+  # GOOGLE_SECRET: *********
+  GUNICORN_PORT: "8000"
+  # PRIVATE_KEY:
+  # PUBLIC_KEY:
+{{ end }}

--- a/charts-external/auth/templates/deployment.yaml
+++ b/charts-external/auth/templates/deployment.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.enabled }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: auth
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: auth
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: auth
+        image: {{ .Values.image | default "datopian/auth:latest" | quote }}
+        ports:
+        - containerPort: 8000
+        resources: {{ .Values.resources }}
+        envFrom:
+        - configMapRef:
+            name: auth
+        {{ if .Values.secretName }}
+        # override the values from configmap
+        - secretRef:
+            name: {{ .Values.secretName | quote }}
+        {{ end }}
+{{ end }}

--- a/charts-external/list-manager/healthcheck.sh
+++ b/charts-external/list-manager/healthcheck.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-echo chart is not ready, skipping health check
-exit 0
-
 kubectl rollout status deployment/list-manager

--- a/charts-external/list-manager/templates/deployment.yaml
+++ b/charts-external/list-manager/templates/deployment.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.enabled }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: list-manager
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: list-manager
+    spec:
+      containers:
+      - name: list-manager
+        image: {{ .Values.image | default "budgetkey/budgetkey-list-manager:latest" | quote }}
+        ports:
+        - containerPort: 8000
+        resources: {{ .Values.resources }}
+        env:
+        - name: AUTH_SERVER
+          value: http://auth:8000/auth/public-key
+        - name: GUNICORN_PORT
+          value: "8000"
+        - name: DATABASE_URL
+          valueFrom: {secretKeyRef: {name: {{ .Values.secretName | quote }}, key: DATABASE_URL}}
+{{ end }}

--- a/charts-external/migration-from-docker-cloud/README.md
+++ b/charts-external/migration-from-docker-cloud/README.md
@@ -1,0 +1,29 @@
+# Migration from Docker Cloud
+
+## Postgres
+
+* clear existing data
+
+```
+NODE_NAME=`kubectl get pod -lapp=postgres '-ojsonpath={.items[0].spec.nodeName}'`
+kubectl delete deployment postgres
+utils/ops-pod/run.sh ori-ops node=${NODE_NAME},gcepd=budgetkey-postgres-data -- sh -c 'rm -rf /gcepd/*'
+```
+
+* stop writes to old DB
+* enable the db migration job and set relevant values under `migration-from-docker-cloud`
+* `./helm_upgrade_external_chart.sh migration-from-docker-cloud`
+* Wait for job to complete - `kubectl get job db-migration`
+* `./helm_upgrade_external_chart.sh postgres`
+
+## Elasticsearch
+
+* clear existing data - same as for postgres
+* stop writes to old Elasticsearch
+* enable and run the migration job - same as for postgres
+
+## Datapackages
+
+* enable and run the migration job - wait for completion
+* enable and run the datapackage permissions job
+

--- a/charts-external/pipelines/healthcheck.sh
+++ b/charts-external/pipelines/healthcheck.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-echo chart is not ready, skipping health check
-exit 0
-
 kubectl rollout status deployment/pipelines

--- a/charts-external/pipelines/templates/deployment.yaml
+++ b/charts-external/pipelines/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         image: {{ .Values.image | default "budgetkey/budgetkey-data-pipelines:latest" | quote }}
         ports:
         - containerPort: 8000
-        resources: {{ .Values.mainpageResources }}
+        resources: {{ .Values.resources }}
         envFrom:
         - configMapRef:
             name: pipelines

--- a/charts-external/search-api/healthcheck.sh
+++ b/charts-external/search-api/healthcheck.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-echo chart is not ready, skipping health check
-exit 0
-
 kubectl rollout status deployment/search-api

--- a/charts-external/search-api/templates/deployment.yaml
+++ b/charts-external/search-api/templates/deployment.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.enabled }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: search-api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: search-api
+    spec:
+      containers:
+      - name: search-api
+        image: {{ .Values.image | default "budgetkey/open-budget-search-api:latest" | quote }}
+        ports:
+        - containerPort: 8000
+        resources: {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"cpu": "100m", "memory": "200Mi"}}
+        env:
+        - name: DB_DB
+          value: {{ .Values.DB_DB | default "obudget" | quote }}
+        - name: DB_HOST
+          value: {{ .Values.DB_HOST | default "postgres" | quote }}
+        - name: DB_PORT
+          value: {{ .Values.DB_PORT | default "5432" | quote }}
+        - name: ES_HOST
+          value: elasticsearch
+        - name: ES_PORT
+          value: "9200"
+        - name: INDEX_NAME
+          value: {{ .Values.INDEX_NAME | default "budgetkey_20180319232948938759_e07786a8" | quote }}
+        {{ if .Values.secretName }}
+        - name: DB_PWD
+          valueFrom: {secretKeyRef: {name: {{ .Values.secretName | quote }}, key: DB_PWD}}
+        - name: DB_USER
+          valueFrom: {secretKeyRef: {name: {{ .Values.secretName | quote }}, key: DB_USER}}
+        {{ else }}
+        - name: DB_PWD
+          value: "123456"
+        - name: DB_USER
+          value: budgetkey
+        {{ end }}
+{{ end }}

--- a/docker-cloud.yaml.deprecated
+++ b/docker-cloud.yaml.deprecated
@@ -79,18 +79,18 @@ budgetkey-app-search:
 #     - '/mnt/budgetkey-persistent-data/.ssh:/home/dpp/.ssh'
 #   volumes_from:
 #     - open-budget-nginx-frontend
-budgetkey-list-manager:
-  autoredeploy: true
-  environment:
-    - 'AUTH_SERVER=http://auth:8000/auth/public-key'
-    - 'DATABASE_URL=postgresql://*********@budgetkey-postgres/private'
-    - GUNICORN_PORT=8000
-  expose:
-    - '8000'
-  image: 'budgetkey/budgetkey-list-manager:latest'
-  restart: always
-  tags:
-    - budget-key
+# budgetkey-list-manager:
+#   autoredeploy: true
+#   environment:
+#     - 'AUTH_SERVER=http://auth:8000/auth/public-key'
+#     - 'DATABASE_URL=postgresql://*********@budgetkey-postgres/private'
+#     - GUNICORN_PORT=8000
+#   expose:
+#     - '8000'
+#   image: 'budgetkey/budgetkey-list-manager:latest'
+#   restart: always
+#   tags:
+#     - budget-key
 # budgetkey-postgres:
 #   autoredeploy: true
 #   environment:
@@ -183,23 +183,23 @@ dd-agent:
 #   volumes:
 #     - '/mnt/budgetkey-persistent-data/datapackages:/var/datapackages'
 #     - '/mnt/budgetkey-persistent-data/fonts:/var/_fonts'
-open-budget-search-api:
-  autoredeploy: true
-  environment:
-    - DB_DB=obudget
-    - DB_HOST=data.obudget.org
-    - DB_PORT=5432
-    - DB_PWD=*********
-    - DB_USER=*********
-    - ES_HOST=open-budget-elasticsearch
-    - ES_PORT=9200
-    - INDEX_NAME=budgetkey_20180319232948938759_e07786a8
-  image: 'budgetkey/open-budget-search-api:latest'
-  links:
-    - open-budget-elasticsearch
-  restart: always
-  tags:
-    - budget-key
+# open-budget-search-api:
+#   autoredeploy: true
+#   environment:
+#     - DB_DB=obudget
+#     - DB_HOST=data.obudget.org
+#     - DB_PORT=5432
+#    - DB_PWD=*********
+#    - DB_USER=*********
+#     - ES_HOST=open-budget-elasticsearch
+#     - ES_PORT=9200
+#     - INDEX_NAME=budgetkey_20180319232948938759_e07786a8
+#  image: 'budgetkey/open-budget-search-api:latest'
+#  links:
+#    - open-budget-elasticsearch
+#  restart: always
+#  tags:
+#    - budget-key
 # open-procure:
 #   autoredeploy: true
 #   image: 'budgetkey/open-procure:latest'

--- a/docker-cloud.yaml.deprecated
+++ b/docker-cloud.yaml.deprecated
@@ -1,24 +1,24 @@
-auth:
-  environment:
-    - 'DATABASE_URL=postgresql://*********@budgetkey-postgres/private'
-    - EXTERNAL_ADDRESS=next.obudget.org
-    - GOOGLE_KEY=*********.apps.googleusercontent.com
-    - GOOGLE_SECRET=*********
-    - GUNICORN_PORT=8000
-    - |-
-      PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----
-      *********
-      -----END RSA PRIVATE KEY-----
-    - |-
-      PUBLIC_KEY=-----BEGIN PUBLIC KEY-----
-      *********
-      -----END PUBLIC KEY-----
-  image: 'datopian/auth:latest'
-  ports:
-    - '8000'
-  restart: always
-  tags:
-    - budget-key
+# auth:
+#   environment:
+#     - 'DATABASE_URL=postgresql://*********@budgetkey-postgres/private'
+#     - EXTERNAL_ADDRESS=next.obudget.org
+#     - GOOGLE_KEY=*********.apps.googleusercontent.com
+#     - GOOGLE_SECRET=*********
+#     - GUNICORN_PORT=8000
+#     - |-
+#       PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----
+#       *********
+#       -----END RSA PRIVATE KEY-----
+#     - |-
+#       PUBLIC_KEY=-----BEGIN PUBLIC KEY-----
+#       *********
+#       -----END PUBLIC KEY-----
+#   image: 'datopian/auth:latest'
+#   ports:
+#     - '8000'
+#   restart: always
+#   tags:
+#     - budget-key
 authorizedkeys:
   autodestroy: always
   deployment_strategy: every_node
@@ -53,32 +53,32 @@ budgetkey-app-search:
     - budget-key
   volumes:
     - '/mnt/budgetkey-persistent-data/themes:/themes'
-budgetkey-data-pipelines:
-  autoredeploy: true
-  environment:
-    - AWS_ACCESS_KEY_ID=*********
-    - AWS_SECRET_ACCESS_KEY=*********
-    - 'BUDGETKEY_OLD_DB=postgresql://*********@data.obudget.org/obudget'
-    - 'DATABASE_URL=postgresql://*********@budgetkey-postgres/budgetkey'
-    - 'DATAHUB_ENDPOINT=https://api.datahub.io'
-    - DATAHUB_OWNER=budgetkey
-    - DATAHUB_OWNERID=*********
-    - DATAHUB_TOKEN=*********
-    - 'DPP_DB_ENGINE=postgresql://*********@budgetkey-postgres/budgetkey'
-    - 'DPP_ELASTICSEARCH=open-budget-elasticsearch:9200'
-    - GITHUB_AUTH_TOKEN=*********
-    - 'S3_ENDPOINT_URL=https://ams3.digitaloceanspaces.com'
-  image: 'budgetkey/budgetkey-data-pipelines:latest'
-  links:
-    - open-budget-elasticsearch
-  restart: always
-  tags:
-    - budget-key
-  volumes:
-    - '/mnt/budgetkey-persistent-data/redis:/var/redis'
-    - '/mnt/budgetkey-persistent-data/.ssh:/home/dpp/.ssh'
-  volumes_from:
-    - open-budget-nginx-frontend
+# budgetkey-data-pipelines:
+#   autoredeploy: true
+#   environment:
+#     - AWS_ACCESS_KEY_ID=*********
+#     - AWS_SECRET_ACCESS_KEY=*********
+#     - 'BUDGETKEY_OLD_DB=postgresql://*********@data.obudget.org/obudget'
+#     - 'DATABASE_URL=postgresql://*********@budgetkey-postgres/budgetkey'
+#     - 'DATAHUB_ENDPOINT=https://api.datahub.io'
+#     - DATAHUB_OWNER=budgetkey
+#     - DATAHUB_OWNERID=*********
+#     - DATAHUB_TOKEN=*********
+#     - 'DPP_DB_ENGINE=postgresql://*********@budgetkey-postgres/budgetkey'
+#     - 'DPP_ELASTICSEARCH=open-budget-elasticsearch:9200'
+#     - GITHUB_AUTH_TOKEN=*********
+#     - 'S3_ENDPOINT_URL=https://ams3.digitaloceanspaces.com'
+#   image: 'budgetkey/budgetkey-data-pipelines:latest'
+#   links:
+#     - open-budget-elasticsearch
+#   restart: always
+#   tags:
+#     - budget-key
+#   volumes:
+#     - '/mnt/budgetkey-persistent-data/redis:/var/redis'
+#     - '/mnt/budgetkey-persistent-data/.ssh:/home/dpp/.ssh'
+#   volumes_from:
+#     - open-budget-nginx-frontend
 budgetkey-list-manager:
   autoredeploy: true
   environment:
@@ -103,23 +103,23 @@ budgetkey-list-manager:
 #     - budget-key
 #   volumes:
 #     - '/mnt/budgetkey-persistent-data/db:/var/lib/postgresql/data/db'
-db-backup:
-  autoredeploy: true
-  environment:
-    - AWS_ACCESS_KEY=*********
-    - AWS_SECRET_KEY=*********
-    - S3_BUCKET=budgetkey-files
-    - S3_HOST=ams3.digitaloceanspaces.com
-    - 'S3_HOST_BUCKET=%(bucket)s.ams3.digitaloceanspaces.com'
-    - S3_NAMESPACE=budgetkey
-    - old_AWS_ACCESS_KEY=*********
-    - old_AWS_SECRET_KEY=*********
-  image: 'openknowledge/dockercloud-db-to-s3:latest'
-  restart: always
-  roles:
-    - global
-  tags:
-    - budget-key
+# db-backup:
+#   autoredeploy: true
+#   environment:
+#     - AWS_ACCESS_KEY=*********
+#     - AWS_SECRET_KEY=*********
+#     - S3_BUCKET=budgetkey-files
+#     - S3_HOST=ams3.digitaloceanspaces.com
+#     - 'S3_HOST_BUCKET=%(bucket)s.ams3.digitaloceanspaces.com'
+#     - S3_NAMESPACE=budgetkey
+#     - old_AWS_ACCESS_KEY=*********
+#     - old_AWS_SECRET_KEY=*********
+#   image: 'openknowledge/dockercloud-db-to-s3:latest'
+#   restart: always
+#   roles:
+#     - global
+#   tags:
+#     - budget-key
 dd-agent:
   deployment_strategy: every_node
   environment:

--- a/environments/budgetkey/values.yaml
+++ b/environments/budgetkey/values.yaml
@@ -17,8 +17,7 @@ postgres:
   loadBalancerIP: 35.189.219.73
 
 elasticsearch:
-  # disabled while running the migration
-  enabled: false
+  enabled: true
   # gcloud --project=next-obudget-org compute disks create --size=100GB --zone=europe-west1-b budgetkey-elasticsearch-data
   gcePersistentDiskName: budgetkey-elasticsearch-data
   resources: >
@@ -52,20 +51,20 @@ data-api:
   secretName: data-api
 
 migration-from-docker-cloud:
-  enabled: true
+  enabled: false
   datapackagesEnabled: false
   fontsEnabled: false
   redisEnabled: false
   sshEnabled: false
   setSshPermissionsEnabled: false
   setDatapackagesPermissionsEnabled: false
-  setRedisPermissionsEnabled: true
+  setRedisPermissionsEnabled: false
   # persistent disks can only be mounted write from one node, stop the db/elasticsearch pods sbefore running the job
   # better to run it on the same node as the DB, so a re-mount of the persistent disk won't be needed
   dbEnabled: false
   dbPersistentDiskName: budgetkey-postgres-data
   dbNodeName: gke-budgetkey-default-pool-bfb61637-qzv3
-  elasticsearchEnabled: true
+  elasticsearchEnabled: false
   elasticsearchPersistentDiskName: budgetkey-elasticsearch-data
   elasticsearchNodeName: gke-budgetkey-default-pool-bfb61637-sczn
   # kubectl create secret generic data-migration --from-file=private_key=/path/to/private/key \
@@ -91,3 +90,7 @@ auth:
   secretName: auth
   resources: >
     {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"cpu": "100m", "memory": "300Mi"}}
+
+list-manager:
+  # kubectl create secret generic list-manager --from-literal=DATABASE_URL=
+  secretName: list-manager

--- a/environments/budgetkey/values.yaml
+++ b/environments/budgetkey/values.yaml
@@ -52,19 +52,20 @@ data-api:
   secretName: data-api
 
 migration-from-docker-cloud:
-  enabled: false
+  enabled: true
   datapackagesEnabled: false
   fontsEnabled: false
   redisEnabled: false
   sshEnabled: false
   setSshPermissionsEnabled: false
   setDatapackagesPermissionsEnabled: false
+  setRedisPermissionsEnabled: true
   # persistent disks can only be mounted write from one node, stop the db/elasticsearch pods sbefore running the job
   # better to run it on the same node as the DB, so a re-mount of the persistent disk won't be needed
   dbEnabled: false
   dbPersistentDiskName: budgetkey-postgres-data
   dbNodeName: gke-budgetkey-default-pool-bfb61637-qzv3
-  elasticsearchEnabled: false
+  elasticsearchEnabled: true
   elasticsearchPersistentDiskName: budgetkey-elasticsearch-data
   elasticsearchNodeName: gke-budgetkey-default-pool-bfb61637-sczn
   # kubectl create secret generic data-migration --from-file=private_key=/path/to/private/key \
@@ -82,3 +83,11 @@ pipelines:
   enableAntiAffinity: true
   # see the pipelines configmap for the required keys
   secretName: pipelines
+  resources: >
+    {"requests": {"cpu": "600m", "memory": "500Mi"}, "limits": {"cpu": "800m", "memory": "1.5Gi"}}
+
+auth:
+  # see the auth configmap for the required keys
+  secretName: auth
+  resources: >
+    {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"cpu": "100m", "memory": "300Mi"}}

--- a/environments/budgetkey/values.yaml
+++ b/environments/budgetkey/values.yaml
@@ -94,3 +94,6 @@ auth:
 list-manager:
   # kubectl create secret generic list-manager --from-literal=DATABASE_URL=
   secretName: list-manager
+
+search-api:
+  secretName: data-api

--- a/utils/ops-pod/Chart.yaml
+++ b/utils/ops-pod/Chart.yaml
@@ -1,0 +1,1 @@
+name: ops-pod

--- a/utils/ops-pod/run.sh
+++ b/utils/ops-pod/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+NAME="${1}"
+[ -z "${NAME}" ] && echo a unique name argument is required && exit 1
+
+EXTRA_VALUES="${2}"
+! [ -z "${EXTRA_VALUES}" ] && EXTRA_VALUES=",${EXTRA_VALUES}"
+
+EXEC_PARAMS="${@:3}"
+[ -z "${EXEC_PARAMS}" ] && EXEC_PARAMS="sh"
+
+helm delete --purge "${NAME}" >/dev/null 2>&1 && while kubectl get pods "${NAME}"; do sleep 1; printf .; done
+helm upgrade "${NAME}" utils/ops-pod --install --set "name=${NAME}${EXTRA_VALUES}" &&\
+while [ "$(kubectl get pods "${NAME}" '-ojsonpath={.status.phase}')" != "Running" ]; do
+    sleep 1
+    printf .
+done &&\
+kubectl exec -it "${NAME}" $EXEC_PARAMS
+RES=$?
+kubectl delete pod "${NAME}"
+exit $RES

--- a/utils/ops-pod/templates/pod.yaml
+++ b/utils/ops-pod/templates/pod.yaml
@@ -1,0 +1,33 @@
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: {{ .Values.name }}
+spec:
+  {{ if .Values.node }}
+  nodeSelector:
+    kubernetes.io/hostname: {{ .Values.node | quote }}
+  {{ end }}
+  containers:
+  - name: "ops"
+    image: {{ .Values.image | default "alpine" | quote }}
+    command:
+    - sh
+    - "-c"
+    - {{ .Values.shScript | default "while true; do sleep 86400; done" | quote }}
+    volumeMounts:
+    - name: hostpath-var
+      mountPath: /hostpath/var
+    {{ if .Values.gcepd }}
+    - name: gcepd
+      mountPath: /gcepd
+    {{ end }}
+  volumes:
+  - name: hostpath-var
+    hostPath:
+      path: /var
+      type: Directory
+  {{ if .Values.gcepd }}
+  - name: gcepd
+    gcePersistentDisk:
+      pdName: {{ .Values.gcepd | quote }}
+  {{ end }}


### PR DESCRIPTION
* added charts: auth, list manager, search api
* added migration doc - charts-external/migration-from-docker-cloud/README.md
* added ops pod to allow opening a shell in the cluster (with optional volume mounts / secrets)