### PR TITLE
reduce costs

### DIFF
--- a/charts-external/elasticsearch/templates/deployment.yaml
+++ b/charts-external/elasticsearch/templates/deployment.yaml
@@ -9,7 +9,7 @@ spec:
     type: Recreate
   {{ if .Values.enableAntiAffinity }}
   affinity:
-    # ensure elasticsearch won't be on the same node as nginx and pipelines
+    # ensure elasticsearch won't be on the same node as nginx, pipelines or postgres
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:

--- a/charts-external/nginx/templates/deployment.yaml
+++ b/charts-external/nginx/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
         ports:
         - containerPort: 80
           {{ if .Values.enableHostPorts }}hostPort: 80{{ end }}
-        - containerPort: 5601
-          {{ if .Values.enableHostPorts }}hostPort: 5601{{ end }}
         resources: {{ .Values.resources }}
         {{ if .Values.overrideStartupScript }}
         command:

--- a/charts-external/nginx/templates/deployment.yaml
+++ b/charts-external/nginx/templates/deployment.yaml
@@ -5,9 +5,13 @@ metadata:
   name: nginx
 spec:
   replicas: 1
+  {{ if .Values.enableHostPorts }}
+  strategy:
+    type: Recreate
+  {{ end }}
   {{ if .Values.enableAntiAffinity }}
   affinity:
-    # ensure nginx won't be on the same node as elasticsearch or postgres
+    # ensure nginx won't be on the same node as elasticsearch
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:
@@ -16,7 +20,7 @@ spec:
             operator: In
             values:
             - elasticsearch
-            - postgres
+            # - postgres
         topologyKey: "kubernetes.io/hostname"
   {{ end }}
   template:
@@ -33,14 +37,15 @@ spec:
         image: {{ .Values.image | default "budgetkey/open-budget-nginx-frontend:latest" | quote }}
         ports:
         - containerPort: 80
+          {{ if .Values.enableHostPorts }}hostPort: 80{{ end }}
         - containerPort: 5601
+          {{ if .Values.enableHostPorts }}hostPort: 5601{{ end }}
         resources: {{ .Values.resources }}
         {{ if .Values.overrideStartupScript }}
         command:
         - sh
         - "-c"
-        - |
-          {{ .Values.overrideStartupScript }}
+        - {{ .Values.overrideStartupScript | quote }}
         {{ end }}
         volumeMounts:
         - mountPath: /var/datapackages

--- a/charts-external/nginx/templates/service.yaml
+++ b/charts-external/nginx/templates/service.yaml
@@ -6,8 +6,6 @@ spec:
   ports:
   - name: '80'
     port: 80
-  - name: '5601'
-    port: 5601
   selector:
     app: nginx
   {{ if .Values.enableLoadBalancer }}

--- a/charts-external/pipelines/templates/deployment.yaml
+++ b/charts-external/pipelines/templates/deployment.yaml
@@ -9,7 +9,7 @@ spec:
     type: Recreate
   {{ if .Values.enableAntiAffinity }}
   affinity:
-    # ensure pipelines won't be on the same node as elasticsearch or postgres
+    # ensure pipelines won't be on the same node as elasticsearch
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:
@@ -18,7 +18,7 @@ spec:
             operator: In
             values:
             - elasticsearch
-            - postgres
+            # - postgres
         topologyKey: "kubernetes.io/hostname"
   {{ end }}
   template:

--- a/charts-external/postgres/templates/deployment.yaml
+++ b/charts-external/postgres/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         image: {{ .Values.image | default "budgetkey/budgetkey-postgres:latest" | quote }}
         ports:
         - containerPort: 5432
+          {{ if .Values.enableHostPorts }}hostPort: 5432{{ end }}
         resources: {{ .Values.resources }}
         env:
         - name: POSTGRES_PASSWORD

--- a/db.sh
+++ b/db.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-kubectl exec -it `kubectl get pods | grep postgres | cut -c-40` -- bash -c 'cd ~postgres && su postgres sh -c "psql budgetkey"'
+kubectl exec -it $(kubectl get pods -l app=postgres -o 'jsonpath={.items[0].metadata.name}') \
+    -- bash -c 'cd ~postgres && su postgres sh -c "psql budgetkey"'

--- a/environments/budgetkey/values.yaml
+++ b/environments/budgetkey/values.yaml
@@ -85,7 +85,7 @@ pipelines:
   # see the pipelines configmap for the required keys
   secretName: pipelines
   resources: >
-    {"requests": {"cpu": "800m", "memory": "2Gi"}, "limits": {"cpu": "1500m", "memory": "5Gi"}}
+    {"requests": {"cpu": "200m", "memory": "2Gi"}, "limits": {"memory": "3Gi"}}
   # prevents pipelines from scheduling on the same node as elasticsearch
   enableAntiAffinity: true
 
@@ -99,6 +99,6 @@ postgres:
   # gcloud --project=next-obudget-org compute addresses describe budgetkey-postgres --region=europe-west1 | grep ^address:
   loadBalancerIP: 35.189.219.73
   resources: >
-    {"requests": {"cpu": "800m", "memory": "2Gi"}, "limits": {"cpu": "1500m", "memory": "5Gi"}}
+    {"requests": {"cpu": "200m", "memory": "2Gi"}, "limits": {"memory": "3Gi"}}
   # prevents postgres from scheduling on the same node as elasticsearch and pipelines
   enableAntiAffinity: true

--- a/environments/ori-gke/.env
+++ b/environments/ori-gke/.env
@@ -1,7 +1,7 @@
 CLOUDSDK_CORE_PROJECT=next-obudget-org
-CLOUDSDK_CONTAINER_CLUSTER=budgetkey
+CLOUDSDK_CONTAINER_CLUSTER=ori-test-budgetkey
 CLOUDSDK_COMPUTE_ZONE=europe-west1-b
 K8S_NAMESPACE=ori-gke
 K8S_HELM_RELEASE_NAME=budgetkey
 K8S_ENVIRONMENT_NAME=ori-gke
-K8S_ENVIRONMENT_CONTEXT=gke_next-obudget-org_europe-west1-b_budgetkey
+K8S_ENVIRONMENT_CONTEXT=gke_next-obudget-org_europe-west1-b_ori-test-budgetkey

--- a/environments/ori-gke/values.yaml
+++ b/environments/ori-gke/values.yaml
@@ -1,2 +1,16 @@
 global:
   namespace: ori-gke
+
+nginx:
+  enableHostPorts: true
+  overrideStartupScript: |
+    echo 'location /datapackages {
+      root /var/;
+      autoindex on;
+    } ' > /etc/nginx/server-rules.conf
+    rm /etc/nginx/conf.d/kibana.conf
+    echo 127.0.0.1 socialmap-app-main-page >> /etc/hosts
+    nginx -g "daemon off;"
+
+postgres:
+  enableHostPorts: true

--- a/values.yaml
+++ b/values.yaml
@@ -5,27 +5,27 @@ global:
 app-generic-item:
   enabled: true
   resources: >
-    {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "15m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 app-main-page:
   enabled: true
   resources: >
-    {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "15m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 app-search:
   enabled: true
   resources: >
-    {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "15m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 auth:
   enabled: true
   resources: >
-    {"requests": {"cpu": "75m", "memory": "150Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "25m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 data-api:
   enabled: true
   resources: >
-    {"requests": {"cpu": "75m", "memory": "150Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "35m", "memory": "50Mi"}, "limits": {"memory": "300Mi"}}
 
 db-backup:
   enabled: true
@@ -46,17 +46,17 @@ kibana:
 list-manager:
   enabled: true
   resources: >
-    {"requests": {"cpu": "75m", "memory": "150Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "25m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 nginx:
   enabled: true
   resources: >
-    {"requests": {"cpu": "100m", "memory": "150Mi"}, "limits": {"memory": "500Mi"}}
+    {"requests": {"cpu": "50m", "memory": "150Mi"}, "limits": {"memory": "750Mi"}}
 
 openprocure:
   enabled: true
   mainpageResources: >
-    {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "15m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 pipelines:
   enabled: true
@@ -71,14 +71,14 @@ postgres:
 search-api:
   enabled: true
   resources: >
-    {"requests": {"cpu": "75m", "memory": "150Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "35m", "memory": "50Mi"}, "limits": {"memory": "300Mi"}}
 
 socialmap:
   enabled: true
   mainpageResources: >
-    {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
+    {"requests": {"cpu": "15m", "memory": "100Mi"}, "limits": {"memory": "300Mi"}}
 
 themes:
   enabled: true
   resources: >
-    {"requests": {"cpu": "10m", "memory": "100Mi"}, "limits": {"cpu": "50m", "memory": "200Mi"}}
+    {"requests": {"cpu": "1m", "memory": "10Mi"}, "limits": {"memory": "200Mi"}}


### PR DESCRIPTION
* reduce resource requests
* add option to use host port instead of load balancers
* allow pipelines and postgres on same node

### deployment
1. apply firewall rules to open ports 80 and 5432 on the nodes (via the google web ui)
2. merge to apply the resource updates (will cause down-time)
3. make sure nginx and postgres static ips are released from the load balancers (kubernetes should do it, if not, release manually in the google ui)
4. drain one of the default pool nodes
5. attach the static ips to the node
6. delete the other node
```
gcloud compute instance-groups managed delete-instances VM_INSTANCES_GROUP_ID --instances=VM_INSTANCE_ID &&\
gcloud compute instance-groups managed wait-until-stable VM_INSTANCES_GROUP_ID
```
