### PR TITLE
add vertical pod autoscalers (recommending only) + helm3 by default

### DIFF
--- a/charts-external/app-about/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/app-about/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-app-about
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: app-about

--- a/charts-external/app-dashboards/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/app-dashboards/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-app-dashboards
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: app-dashboards

--- a/charts-external/app-generic-item/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/app-generic-item/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-app-generic-item
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: app-generic-item

--- a/charts-external/app-main-page/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/app-main-page/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-app-main-page
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: app-main-page

--- a/charts-external/app-profile/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/app-profile/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-app-profile
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: app-profile

--- a/charts-external/app-search/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/app-search/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-app-search
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: app-search

--- a/charts-external/auth/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/auth/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-auth
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: auth

--- a/charts-external/data-api/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/data-api/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-data-api
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: data-api

--- a/charts-external/db-backup/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/db-backup/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-db-backup
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: db-backup

--- a/charts-external/dgp-server/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/dgp-server/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-dgp-server
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: dgp-server

--- a/charts-external/dgp-ui/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/dgp-ui/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-dgp-ui
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: dgp-ui

--- a/charts-external/elasticsearch-new/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/elasticsearch-new/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-elasticsearch-new
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: elasticsearch-new

--- a/charts-external/elasticsearch/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/elasticsearch/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-elasticsearch
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: elasticsearch

--- a/charts-external/emails/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/emails/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-emails
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: emails

--- a/charts-external/kibana/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/kibana/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-kibana
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: kibana

--- a/charts-external/list-manager/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/list-manager/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-list-manager
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: list-manager

--- a/charts-external/nginx/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/nginx/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-nginx
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: nginx

--- a/charts-external/openprocure/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/openprocure/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-openprocure-app-main-page
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: openprocure-app-main-page

--- a/charts-external/pipelines/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/pipelines/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-pipelines
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: pipelines

--- a/charts-external/postgres/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/postgres/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-postgres
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: postgres

--- a/charts-external/search-api-new/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/search-api-new/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-search-api-new
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: search-api-new

--- a/charts-external/search-api/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/search-api/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-search-api
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: search-api

--- a/charts-external/socialmap/templates/vertical-pod-autoscaler.yaml
+++ b/charts-external/socialmap/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,9 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: deployment-socialmap-app-main-page
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: deployment
+    name: socialmap-app-main-page

--- a/helm_lint_all.sh
+++ b/helm_lint_all.sh
@@ -4,12 +4,7 @@ RES=0
 
 echo "Linting all charts"
 for CHART_NAME in `ls charts-external`; do
-    if [ "$(eval echo `./read_yaml.py "charts-external/${CHART_NAME}/Chart.yaml" apiVersion 2>/dev/null`)" == "v2" ]; then
-      HELM_BIN=helm3
-    else
-      HELM_BIN=helm
-    fi
-    $HELM_BIN lint charts-external/$CHART_NAME 2>/dev/null | grep 'ERROR' | grep -v 'Chart.yaml: version is required'
+    helm lint charts-external/$CHART_NAME 2>/dev/null | grep 'ERROR' | grep -v 'Chart.yaml: version is required'
     if [ "$?" == "0" ]; then
         echo "${CHART_NAME}: failed lint"
         RES=1

--- a/helm_upgrade_external_chart.sh
+++ b/helm_upgrade_external_chart.sh
@@ -33,14 +33,8 @@ done
 
 VALUES=`cat "${TEMPDIR}/values.yaml"`
 
-if [ "$(eval echo `./read_yaml.py "${CHART_DIRECTORY}/Chart.yaml" apiVersion 2>/dev/null`)" == "v2" ]; then
-  HELM_BIN=helm3
-else
-  HELM_BIN=helm
-fi
-
 if [ "`./read_yaml.py "${TEMPDIR}/values.yaml" enabled 2>/dev/null`" == "true" ]; then
-    CMD="$HELM_BIN upgrade -f ${TEMPDIR}/values.yaml ${RELEASE_NAME} ${CHART_DIRECTORY} ${@:2}"
+    CMD="helm upgrade -f ${TEMPDIR}/values.yaml ${RELEASE_NAME} ${CHART_DIRECTORY} ${@:2}"
     if ! $CMD; then
         echo
         echo "${TEMPDIR}/values.yaml"


### PR DESCRIPTION
* Add veritcal pod autoscalers - currently only providing recommendations for cpu/ram request/limits, recommendations will be available on the VeritcalPodAutoscaler objects status
* Switch to use Helm3 by default (we already use helm3 for all charts, this change drops support for helm2 and matches the helm version installed by hasadna-k8s apps_travis_script)
