### PR TITLE
Switch storage to PVC (+upgrade ingresses)

### DIFF
--- a/charts-external/elasticsearch8/templates/deployment.yaml
+++ b/charts-external/elasticsearch8/templates/deployment.yaml
@@ -122,9 +122,14 @@ spec:
           mountPath: /usr/share/elasticsearch/data
       volumes:
       - name: esdata
+      {{- if .Values.pvcName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.pvcName | quote }}
+      {{- else }}
         nfs:
           server: {{ .Values.nfsServer | quote }}
           path: {{ .Values.nfsPathEsData | quote }}
+      {{- end }}
       - name: certs
         nfs:
           server: {{ .Values.nfsServer | quote }}

--- a/charts-external/pipelines/templates/deployment.yaml
+++ b/charts-external/pipelines/templates/deployment.yaml
@@ -86,9 +86,14 @@ spec:
           subPath: budgetkey-persistent-data/datapackages
       volumes:
       - name: data
+      {{- if .Values.pvcName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.pvcName | quote }}
+      {{- else }}
         nfs:
           server: {{ .Values.nfsServer | quote }}
           path: {{ .Values.nfsPath | quote }}
+      {{- end }}
       - name: escerts
         nfs:
           server: {{ .Values.nfsServer | quote }}

--- a/charts-external/postgres/templates/deployment.yaml
+++ b/charts-external/postgres/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
       {{ if .Values.gcePersistentDiskName }}
         gcePersistentDisk:
           pdName: {{ .Values.gcePersistentDiskName | quote }}
+      {{ else if .Values.pvcName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.pvcName | quote }}
       {{ else if .Values.nfsServer }}
         nfs:
           server: {{ .Values.nfsServer | quote }}

--- a/values-hasadna.yaml
+++ b/values-hasadna.yaml
@@ -30,7 +30,7 @@ emails:
 
 elasticsearch8:
   nfsServer: "172.16.0.9"
-  nfsPathEsData: "/budgetkey/elasticsearch8"
+  pvcName: elasticsearch
   nfsPathEsCerts: "/budgetkey/elasticsearch-certs"
   stackVersion: "8.17.0"
   resources: >
@@ -104,15 +104,14 @@ pipelines:
   # prevents pipelines from scheduling on the same node as elasticsearch
   # enableAntiAffinity: true
   # gcePersistentDiskName: budgetkey-pipelines-data-3
+  pvcName: pipelines
   nfsServer: "172.16.0.9"
-  nfsPath: "/budgetkey/pipelines"
   nfsPathEsCerts: "/budgetkey/elasticsearch-certs"
 
 postgres:
   # gcloud --project=hasadna-general compute disks create --size=100GB --zone=europe-west1-b budgetkey-postgres-data
   # gcePersistentDiskName: budgetkey-postgres-data-2
-  nfsServer: "172.16.0.9"
-  nfsPath: "/budgetkey/postgres"
+  pvcName: postgres
   # kubectl create secret generic postgres --from-literal=POSTGRES_PASSWORD=
   secretName: postgres
   # enableLoadBalancer: true


### PR DESCRIPTION
## Summary
- update Postgres, Pipelines and Elasticsearch8 templates to allow using a persistent volume claim
- default hasadna values now use pre-created PVCs instead of NFS

## Testing
- `helm lint` *(fails: `helm: command not found`)*